### PR TITLE
event journee visu24 publish date

### DIFF
--- a/content/event/journee_visu2024/index.md
+++ b/content/event/journee_visu2024/index.md
@@ -17,7 +17,7 @@ date_end: "2024-06-19T14:00:00Z"
 all_day: false
 
 # Schedule page publish date (NOT talk date).
-publishDate: "2024-04-16"
+publishDate: "2024-03-16"
 
 #authors:
 #  - Jules Vidal


### PR DESCRIPTION
Hi David, 
It seems the publish date was wrong on the event of the journee visu 2024.
Sorry about that, it should be good now.
Best,
Jules